### PR TITLE
Allow full hexadecimal output

### DIFF
--- a/elftoc/elftoc.c
+++ b/elftoc/elftoc.c
@@ -29,6 +29,7 @@ static char const *yowzitch =
     "with the file's contents as its initialized value.\n\n"
     "  -e, --force-end         Force the inclusion of a final _end field.\n"
     "  -E, --exclude-end       Force the _end field to never be included.\n"
+    "  -X, --only-hexadecimal  Force the output of data section to hexadecimal\n"
     "  -m, --allow-misaligned  Ignore alignment problems in fields.\n"
     "  -q, --quiet             Suppress warning messages.\n"
     "  -o, --output=FILE       Write source to FILE instead of stdout.\n"
@@ -41,7 +42,7 @@ static char const *yowzitch =
 
 /* A suffix for command-line parsing errors.
  */
-static char const *helpsuffix = "Try --help for more information.";
+static char const *helpsuffix = "Try --help for more information.\n";
 
 /* The program's version information.
  */
@@ -73,10 +74,11 @@ static int isvalididentifier(char const *name)
  */
 static void parsecmdline(int argc, char *argv[])
 {
-    static char const *optstring = "Eei:mo:qs:v:w:";
+    static char const *optstring = "Eei:mo:qs:v:w:X";
     static struct option options[] = {
 	{ "force-end", no_argument, NULL, 'e' },
 	{ "exclude-end", no_argument, NULL, 'E' },
+	{ "only-hexadecimal", no_argument, NULL, 'X' },
 	{ "allow-misaligned", no_argument, NULL, 'm' },
 	{ "quiet", no_argument, NULL, 'q' },
 	{ "indent", required_argument, NULL, 'i' },
@@ -100,6 +102,7 @@ static void parsecmdline(int argc, char *argv[])
 	switch (n) {
 	  case 'e':	include_end(TRUE);		break;
 	  case 'E':	include_end(FALSE);		break;
+	  case 'X':	only_hexadecimal();		break;
 	  case 'm':	permitmisalignment();		break;
 	  case 'q':	enablewarnings(FALSE);		break;
 	  case 'i':	indent = optarg;		break;

--- a/elftoc/out.c
+++ b/elftoc/out.c
@@ -17,6 +17,18 @@
 #include "outelf32.h"
 #include "out.h"
 
+/* Boolean to display only hexadecimal on data section
+ */
+static int data_hexadecimal = FALSE;
+
+/* Force the output of data sections to be hexadecimal.
+ *
+ */
+void only_hexadecimal(void)
+{
+    data_hexadecimal = TRUE;
+}
+
 /* The output function for a piece not actually present in the ELF
  * file image.
  */
@@ -32,9 +44,9 @@ static void outnothing(void const *ptr, long size, int ndx)
  * P_BYTES, or P_STRINGS. The contents are output either as a literal
  * string, an array of character values, or an array of hexadecimal
  * byte values. The last will be used if the contents contain an
- * excess of non-graphic, non-ASCII characters. Otherwise, one of the
- * first two representations will be selected based on whether or not
- * the contents appear to be NUL-terminated.
+ * excess of non-graphic, non-ASCII characters or the flag set.
+ * Otherwise, one of the first two representations will be selected
+ * based on whether or not the contents appear to be NUL-terminated.
  */
 static void outbytes(void const *ptr, long size, int ndx)
 {
@@ -54,7 +66,7 @@ static void outbytes(void const *ptr, long size, int ndx)
 
     n = outstringsize((char const*)bytes, size);
 
-    if (n * 2 > size * 3) {
+    if ( data_hexadecimal || (n * 2 > size * 3) ) {
 	beginblock(TRUE);
 	for (i = 0 ; i < size - zeroes ; ++i)
 	    outf("0x%02X", bytes[i]);

--- a/elftoc/out.h
+++ b/elftoc/out.h
@@ -19,4 +19,8 @@ extern void outtypedblock(int type, long offset, long size, int ndx);
  */
 extern void output(void);
 
+/* Force hexadecimal on data section.
+*/
+extern void only_hexadecimal(void);
+
 #endif


### PR DESCRIPTION
Sometime, you don't want to have character but only hexadecimal, even in data
section.
I needed it for a ctf challenge, maybe it can be useful to other too.
minor: added a new line in the "more information" string.