### PR TITLE
Allow to use a different toolchain and fix compiler warnings

### DIFF
--- a/ebfc/Makefile
+++ b/ebfc/Makefile
@@ -1,7 +1,9 @@
 #  Makefile for ebfc
 
-CC = gcc
-CFLAGS = -Wall -Wextra -Wno-missing-field-initializers
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -Wno-missing-field-initializers
+AR ?= ar
+ARFLAGS ?= crs
 
 # The main program.
 
@@ -15,7 +17,7 @@ brainfuck.o: brainfuck.c elfparts.h ebfc.h
 libelfparts.a: elfparts.o \
 	       ehdr.o phdrtab.o shdrtab.o progbits.o \
                strtab.o symtab.o hash.o rel.o got.o dynamic.o
-	ar crs libelfparts.a $^
+	$(AR) $(ARFLAGS) libelfparts.a $^
 
 elfparts.o: elfparts.c elfparts.h elfpartsi.h
 ehdr.o: ehdr.c elfparts.h elfpartsi.h

--- a/elfls/Makefile
+++ b/elfls/Makefile
@@ -1,7 +1,7 @@
 #  Makefile for elfls
 
-CC = gcc
-CFLAGS = -Wall -Wextra -I../elfrw
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -I../elfrw
 
 elfls: elfls.c ../elfrw/libelfrw.a
 

--- a/elfls/elfls.c
+++ b/elfls/elfls.c
@@ -78,9 +78,9 @@ static int		ldepls = FALSE;	/* TRUE = show libraries */
 static int		dostrs = TRUE;	/* TRUE = show entry strings */
 static int		dooffs = TRUE;	/* TRUE = show file offsets */
 
-static char		sizefmt[8];	/* num digits to show sizes */
-static char		addrfmt[8];	/* num digits to show addresses */
-static char		offsetfmt[8];	/* num digits to show offsets */
+static char		sizefmt[16];	/* num digits to show sizes */
+static char		addrfmt[16];	/* num digits to show addresses */
+static char		offsetfmt[16];	/* num digits to show offsets */
 static int		outwidth;	/* maximum width of output */
 
 /* The error-reporting function.

--- a/elfrw/Makefile
+++ b/elfrw/Makefile
@@ -1,13 +1,15 @@
 #  Makefile for libelfrw.a
 
-CC = gcc
-CFLAGS = -Wall -Wextra -O3
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -O3
+AR ?= ar
+ARFLAGS ?= crs
 
 LIBOBJS = elfrw.o elfrw_dyn.o elfrw_ehdr.o elfrw_phdr.o elfrw_rel.o \
           elfrw_shdr.o elfrw_sym.o elfrw_ver.o
 
 libelfrw.a: $(LIBOBJS)
-	ar crs $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 elfrw.o: elfrw.c elfrw.h elfrw_int.h
 elfrw_dyn.o: elfrw_dyn.c elfrw_int.h

--- a/elftoc/Makefile
+++ b/elftoc/Makefile
@@ -1,8 +1,9 @@
 #  Makefile for elftoc
 
-CC = gcc
-CFLAGS = -Wall -Wextra
-LDFLAGS = -Wall -Wextra
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra
+LDFLAGS ?= -Wall -Wextra
+CPP ?= $(CC) -E
 
 OBJS = gen.o names.o address.o readelf.o shdrtab.o phdrtab.o dynamic.o \
        pieces.o outbase.o outitems.o outelf64.o outelf32.o out.o elftoc.o

--- a/infect/Makefile
+++ b/infect/Makefile
@@ -1,7 +1,7 @@
 #  Makefile for infect
 
-CC = gcc
-CFLAGS = -Wall -Wextra
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra
 
 infect: infect.c
 

--- a/objres/Makefile
+++ b/objres/Makefile
@@ -1,8 +1,8 @@
 #  Makefile for objres
 
-CC = gcc
-CFLAGS = -Wall -Wextra -I../elfrw
-LDFLAGS = -Wall -Wextra
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -I../elfrw
+LDFLAGS ?= -Wall -Wextra
 
 objres: objres.o ../elfrw/libelfrw.a
 

--- a/rebind/Makefile
+++ b/rebind/Makefile
@@ -1,7 +1,7 @@
 #  Makefile for rebind
 
-CC = gcc
-CFLAGS = -Wall -Wextra -I../elfrw
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -I../elfrw
 
 rebind: rebind.c ../elfrw/libelfrw.a
 

--- a/sstrip/Makefile
+++ b/sstrip/Makefile
@@ -1,7 +1,7 @@
 #  Makefile for sstrip
 
-CC = gcc
-CFLAGS = -Wall -Wextra -I../elfrw
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -I../elfrw
 
 sstrip: sstrip.c ../elfrw/libelfrw.a
 


### PR DESCRIPTION
This changes allow to build the code with a different toolchain.

The increased buffers avoid compiler warnings on x86_64-linux

-- 
Regards ... Detef
